### PR TITLE
fix(is_special): Ensure that active window exists

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,16 @@ pub fn spawn_dim_thread(
 /// Gets whether the current workspace is a special workspace or not.
 ///
 /// This function works by getting which workspace the active window is in.
+///
+/// The if statement is used to make sure this function works when no window
+/// is the active window.
 pub fn is_special() -> bool {
-    let Client { workspace, .. } = Client::get_active().unwrap().unwrap();
+    if let Some(client) = Client::get_active().unwrap() {
+        let Client { workspace, .. } = client;
+        return workspace.name.contains("special");
+    }
 
-    workspace.name.contains("special")
+    false
 }
 
 /// Returns true if there is only one visible window in the special workspace.


### PR DESCRIPTION
This fixes an issue where hyprdim would panic if started with no windows in the active workspace.

This bug was introduced in https://github.com/donovanglover/hyprdim/commit/ce8183c111b9c5e0c5012d46ab1de37c1e0272c0, which means that only v2.1.0 of hyprdim is affected.

Resolves https://github.com/donovanglover/hyprdim/issues/4.