### PR TITLE
chore: prevent log flood when some event are send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.4.7", features = ["derive"] }
 ctrlc = { version = "3.4.1", features = ["termination"] }
-hyprland = "=0.3.9"
+hyprland = { version = "=0.3.9", features = ["silent"] }
 single-instance = "0.3.3"
 
 [build-dependencies]


### PR DESCRIPTION
Hi @donovanglover, happy new year !

Hyprland-autoname-workspace send rename event that are not handled by the version of the lib you use.
But the flag silent exist, so I enable it.

Thanks for this cool project !
